### PR TITLE
ci: 設定変更

### DIFF
--- a/.github/workflows/frontend-checks.yaml
+++ b/.github/workflows/frontend-checks.yaml
@@ -14,10 +14,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 8
           run_install: false
 
       - name: Get pnpm store directory
@@ -34,7 +33,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: checks lint and test
         run: pnpm dlx turbo run lint test
 
@@ -45,10 +44,9 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 8
           run_install: false
 
       - name: Get pnpm store directory
@@ -64,7 +62,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Publish to Chromatic
         uses: chromaui/action@d208304630e76d960a80b9db40a838eb8babcebe # v11
         with:
@@ -72,3 +70,5 @@ jobs:
           workingDir: apps/storybooks
           autoAcceptChanges: 'main'
           buildScriptName: 'build'
+          exitZeroOnChanges: true
+          exitOnceUploaded: true


### PR DESCRIPTION
action-setupがrenovateに捕捉されていないのはなぜ。v4からpackage.jsonのpackageManager見てくれるようになったのでversion削除
installをfrozen-lockfile optionつけた
chromaticのオプション追加