### PR TITLE
chore: renovateの設定変更

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,10 +8,12 @@
     ":disablePrControls",
     ":label(renovate)",
     ":maintainLockFilesWeekly",
-    ":prHourlyLimitNone",
     ":rebaseStalePrs",
     ":semanticCommits",
-    "npm:unpublishSafe"
+    "npm:unpublishSafe",
+    "schedule:daily",
+    ":prConcurrentLimit10",
+    ":prHourlyLimit4"
   ],
   "automergeStrategy": "squash",
   "assigneesFromCodeOwners": true,
@@ -31,6 +33,5 @@
       "groupName": "turbo monorepo",
       "matchUpdateTypes": ["digest", "patch", "minor", "major"]
     }
-  ],
-  "schedule": ["every weekend"]
+  ]
 }


### PR DESCRIPTION
毎日でlimitをhourlyと並列で動くlimitを設定してみた。
hourlyを設定しているのでいいと思うけどmergeされない時とかにいっぱい出てこられても困るのでconcurrent limitも役には立ちそう