### PR TITLE
chore: remove pre-commit hook running lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-npx lint-staged


### PR DESCRIPTION
Remove the pre-commit hook that runs lint-staged to simplify the
commit process. This change is done to avoid potential delays or
conflicts during commits and to streamline the development workflow.