### PR TITLE
feat(blog): add multiple favicon sizes and apple touch icon

### DIFF
--- a/apps/blog/src/layouts/Layout.astro
+++ b/apps/blog/src/layouts/Layout.astro
@@ -56,7 +56,24 @@ const structuredData = {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      rel='apple-touch-icon'
+      sizes='180x180'
+      href='/favicon/apple-touch-icon.png'
+    />
+    <link
+      rel='icon'
+      type='image/png'
+      sizes='32x32'
+      href='/favicon/favicon-32x32.png'
+    />
+    <link
+      rel='icon'
+      type='image/png'
+      sizes='16x16'
+      href='/favicon/favicon-16x16.png'
+    />
+    <link rel='manifest' href='/favicon/site.webmanifest' />
     <link rel="canonical" href={canonicalURL} />
     <meta name="generator" content={Astro.generator} />
 


### PR DESCRIPTION
Replace single SVG favicon with multiple PNG icons for better device
compatibility. Add apple-touch-icon and site manifest to improve
appearance on iOS devices and support progressive web app features.