### PR TITLE
fix(generator): update blog post path and remove module type

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -1,6 +1,5 @@
 {
   "name": "blog",
-  "type": "module",
   "version": "5.4.2",
   "scripts": {
     "dev": "astro dev",

--- a/apps/blog/turbo/generators/config.ts
+++ b/apps/blog/turbo/generators/config.ts
@@ -33,7 +33,7 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
     actions: [
       {
         type: 'add',
-        path: './src/content/blog/{{dashCase slug}}.md',
+        path: './src/data/blog/{{dashCase slug}}.md',
         templateFile: 'templates/blog.hbs',
       },
     ],


### PR DESCRIPTION
Change blog post generator path from src/content to src/data to align
with new project structure. Remove "type": "module" from blog package.json
to fix compatibility issues with CommonJS modules.