### PR TITLE
chore(test): add Playwright and configure e2e testing

### DIFF
--- a/apps/lab/.gitignore
+++ b/apps/lab/.gitignore
@@ -39,3 +39,10 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/apps/lab/.gitignore
+++ b/apps/lab/.gitignore
@@ -41,7 +41,6 @@ yarn-error.log*
 next-env.d.ts
 
 # Playwright
-node_modules/
 /test-results/
 /playwright-report/
 /blob-report/

--- a/apps/lab/package.json
+++ b/apps/lab/package.json
@@ -7,7 +7,10 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "ui:add": "shadcn add"
+    "ui:add": "shadcn add",
+    "test:e2e": "pnpm exec playwright test",
+    "test:e2e:ui": "pnpm exec playwright test --ui",
+    "test:e2e:headed": "pnpm exec playwright test --headed"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "1.2.11",
@@ -22,6 +25,7 @@
     "tailwind-merge": "3.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "@repo/typescript-config": "workspace:*",
     "@tailwindcss/postcss": "^4.1.10",
     "@types/node": "24.0.4",

--- a/apps/lab/playwright.config.ts
+++ b/apps/lab/playwright.config.ts
@@ -1,0 +1,70 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: "./tests",
+  /* 並列でテストを実行 */
+  fullyParallel: true,
+  /* CI環境でのみテストが失敗したときのリトライを無効化 */
+  forbidOnly: !!process.env.CI,
+  /* CI環境でのリトライ設定 */
+  retries: process.env.CI ? 2 : 0,
+  /* CI環境では並列実行数を制限 */
+  workers: process.env.CI ? 1 : undefined,
+  /* レポーターの設定 */
+  reporter: "html",
+  /* すべてのプロジェクトで共有される設定 */
+  use: {
+    /* ベースURL */
+    baseURL: "http://localhost:3000",
+    /* テスト失敗時にトレースを収集 */
+    trace: "on-first-retry",
+  },
+
+  /* プロジェクト設定 */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+
+    /* モバイルビューポートでのテスト */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* ブランドブラウザーでのテスト */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* 開発サーバーの設定 */
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/apps/lab/playwright.config.ts
+++ b/apps/lab/playwright.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices } from '@playwright/test'
 
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  testDir: "./tests",
+  testDir: './tests',
   /* 並列でテストを実行 */
   fullyParallel: true,
   /* CI環境でのみテストが失敗したときのリトライを無効化 */
@@ -14,30 +14,30 @@ export default defineConfig({
   /* CI環境では並列実行数を制限 */
   workers: process.env.CI ? 1 : undefined,
   /* レポーターの設定 */
-  reporter: "html",
+  reporter: 'html',
   /* すべてのプロジェクトで共有される設定 */
   use: {
     /* ベースURL */
-    baseURL: "http://localhost:3000",
+    baseURL: 'http://localhost:3000',
     /* テスト失敗時にトレースを収集 */
-    trace: "on-first-retry",
+    trace: 'on-first-retry',
   },
 
   /* プロジェクト設定 */
   projects: [
     {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
     },
 
     {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
     },
 
     {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
     },
 
     /* モバイルビューポートでのテスト */
@@ -63,8 +63,8 @@ export default defineConfig({
 
   /* 開発サーバーの設定 */
   webServer: {
-    command: "pnpm dev",
-    url: "http://localhost:3000",
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
   },
-});
+})

--- a/apps/lab/tests/example.spec.ts
+++ b/apps/lab/tests/example.spec.ts
@@ -1,32 +1,32 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@playwright/test'
 
 test('ホームページが正しく表示される', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/')
 
   // ページのタイトルを確認
-  await expect(page).toHaveTitle('Create Next App');
+  await expect(page).toHaveTitle('Create Next App')
 
   // Next.jsロゴが表示されることを確認
-  const nextLogo = page.locator('img[alt="Next.js logo"]');
-  await expect(nextLogo).toBeVisible();
-});
+  const nextLogo = page.locator('img[alt="Next.js logo"]')
+  await expect(nextLogo).toBeVisible()
+})
 
 test('基本的なナビゲーションが動作する', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/')
 
   // "Read our docs"リンクが存在することを確認
-  const docsLink = page.getByRole('link', { name: /read our docs/i });
-  await expect(docsLink).toBeVisible();
+  const docsLink = page.getByRole('link', { name: /read our docs/i })
+  await expect(docsLink).toBeVisible()
 
   // "Deploy now"リンクが存在することを確認
-  const deployLink = page.getByRole('link', { name: /deploy now/i });
-  await expect(deployLink).toBeVisible();
-});
+  const deployLink = page.getByRole('link', { name: /deploy now/i })
+  await expect(deployLink).toBeVisible()
+})
 
 test('ページのメインコンテンツが表示される', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/')
 
   // メインの説明テキストが表示されることを確認
-  await expect(page.getByText('Get started by editing')).toBeVisible();
-  await expect(page.getByText('src/app/page.tsx')).toBeVisible();
-});
+  await expect(page.getByText('Get started by editing')).toBeVisible()
+  await expect(page.getByText('src/app/page.tsx')).toBeVisible()
+})

--- a/apps/lab/tests/example.spec.ts
+++ b/apps/lab/tests/example.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test('ホームページが正しく表示される', async ({ page }) => {
+  await page.goto('/');
+
+  // ページのタイトルを確認
+  await expect(page).toHaveTitle('Create Next App');
+
+  // Next.jsロゴが表示されることを確認
+  const nextLogo = page.locator('img[alt="Next.js logo"]');
+  await expect(nextLogo).toBeVisible();
+});
+
+test('基本的なナビゲーションが動作する', async ({ page }) => {
+  await page.goto('/');
+
+  // "Read our docs"リンクが存在することを確認
+  const docsLink = page.getByRole('link', { name: /read our docs/i });
+  await expect(docsLink).toBeVisible();
+
+  // "Deploy now"リンクが存在することを確認
+  const deployLink = page.getByRole('link', { name: /deploy now/i });
+  await expect(deployLink).toBeVisible();
+});
+
+test('ページのメインコンテンツが表示される', async ({ page }) => {
+  await page.goto('/');
+
+  // メインの説明テキストが表示されることを確認
+  await expect(page.getByText('Get started by editing')).toBeVisible();
+  await expect(page.getByText('src/app/page.tsx')).toBeVisible();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,7 +119,7 @@ importers:
         version: 0.523.0(react@19.1.0)
       next:
         specifier: 15.3.4
-        version: 15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -130,6 +130,9 @@ importers:
         specifier: 3.3.1
         version: 3.3.1
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.49.1
+        version: 1.53.1
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
@@ -1147,6 +1150,11 @@ packages:
     resolution: {integrity: sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.53.1':
+    resolution: {integrity: sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -2713,6 +2721,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3819,6 +3832,16 @@ packages:
   pkce-challenge@5.0.0:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.53.1:
+    resolution: {integrity: sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.53.1:
+    resolution: {integrity: sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -5894,6 +5917,10 @@ snapshots:
   '@pagefind/windows-x64@1.3.0':
     optional: true
 
+  '@playwright/test@1.53.1':
+    dependencies:
+      playwright: 1.53.1
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -7619,6 +7646,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8632,7 +8662,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@15.3.4(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.4(@babel/core@7.27.4)(@playwright/test@1.53.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.4
       '@swc/counter': 0.1.3
@@ -8652,6 +8682,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.4
       '@next/swc-win32-arm64-msvc': 15.3.4
       '@next/swc-win32-x64-msvc': 15.3.4
+      '@playwright/test': 1.53.1
       sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -8924,6 +8955,14 @@ snapshots:
   picomatch@4.0.2: {}
 
   pkce-challenge@5.0.0: {}
+
+  playwright-core@1.53.1: {}
+
+  playwright@1.53.1:
+    dependencies:
+      playwright-core: 1.53.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-selector-parser@6.0.10:
     dependencies:


### PR DESCRIPTION
Add Playwright test framework as a dev dependency to enable end-to-end
testing. Introduce a new Playwright config file with parallel test
execution, retry logic for CI, and multiple browser projects (Chromium,
, WebKit). This setup improves test coverage and reliability for
UI components and user flows.