### PR TITLE
chore(release): enable patch bump for minor pre-major releases

### DIFF
--- a/.github/files/release-please/release-please-config.json
+++ b/.github/files/release-please/release-please-config.json
@@ -67,7 +67,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
       "include-component-in-tag": false,


### PR DESCRIPTION
Update release-please configuration to set bump-patch-for-minor-pre-major
to true. This ensures patch versions are incremented during minor pre-major
releases, improving version accuracy and consistency in release management.

ちなみにempty commit作ってrelease-as: 使うとバージョン変えれるみたい。

https://github.com/googleapis/release-please#how-do-i-change-the-version-number