### PR TITLE
feat(blog): add PostHog analytics integration

### DIFF
--- a/apps/blog/src/components/posthog.astro
+++ b/apps/blog/src/components/posthog.astro
@@ -1,0 +1,42 @@
+---
+---
+<script is:inline type="text/javascript" id="posthog-js">
+  !(function(t, e) {
+    var o, n, p, r;
+    e.__SV ||
+      ((window.posthog = e),
+      (e._i = []),
+      (e.init = function(i, s, a) {
+        function g(t, e) {
+          var o = e.split('.');
+          2 == o.length && ((t = t[o[0]]), (e = o[1])),
+            (t[e] = function() {
+              t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+            });
+        }
+        ((p = t.createElement('script')).type = 'text/javascript'),
+          (p.crossOrigin = 'anonymous'),
+          (p.async = true),
+          (p.src = s.api_host + '/static/array.js'),
+          (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r);
+        var u = e;
+        void 0 !== a ? (u = e[a] = []) : (a = 'posthog');
+        u.people = u.people || [];
+        u.toString = function(t) {
+          var e = 'posthog';
+          return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e;
+        };
+        u.people.toString = function() {
+          return u.toString(1) + '.people (stub)';
+        };
+        o =
+          'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId'.split(
+            ' '
+          );
+        for (n = 0; n < o.length; n++) g(u, o[n]);
+        e._i.push([i, s, a]);
+      }),
+      (e.__SV = 1));
+  })(document, window.posthog || []);
+  posthog.init('phc_Tu69I3bh67cjIpkTTAMNjHuezcHVtb7E07d7FlNfXUX', { api_host: 'https://us.i.posthog.com', defaults: '2025-05-24' });
+</script>

--- a/apps/blog/src/layouts/Layout.astro
+++ b/apps/blog/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import { SITE } from '@/config'
 import '@/styles/global.css'
 import { PUBLIC_GOOGLE_SITE_VERIFICATION } from 'astro:env/client'
 import { ClientRouter } from 'astro:transitions'
+import PostHog from '../components/posthog.astro'
 
 export interface Props {
   title?: string
@@ -146,7 +147,7 @@ const structuredData = {
     }
 
     <ClientRouter />
-
+    <PostHog />
     <script is:inline src="/toggle-theme.js"></script>
   </head>
   <body>


### PR DESCRIPTION
Add a new PostHog component to enable user behavior tracking across
the blog. Initialize PostHog with the project key and API host to
collect analytics data. Integrate the PostHog component into the main
Layout to ensure tracking is active on all pages. This change enables
better insights into user interactions and supports data-driven
improvements.