### PR TITLE
fix(package.json): add core-js and msw to built dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
       "nodeVersion": "21.7.3"
     },
     "onlyBuiltDependencies": [
-      "@tailwindcss/oxide"
+      "@tailwindcss/oxide",
+      "core-js",
+      "msw"
     ]
   },
   "packageManager": "pnpm@10.12.4",


### PR DESCRIPTION
Include core-js and msw in the onlyBuiltDependencies list to ensure
these packages are properly bundled during the build process. This
prevents runtime errors caused by missing dependencies and improves
application stability.