### PR TITLE
chore(ci): add issues permission to release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}


### PR DESCRIPTION
Grant the release-please GitHub Actions workflow permission to
write issues. This change enables the workflow to create or update
issues as part of the release process, improving automation and
tracking of release-related tasks.