### PR TITLE
feat(blog): add Noto Sans JP font and apply to OG templates

### DIFF
--- a/apps/blog/src/utils/generateOgImages.ts
+++ b/apps/blog/src/utils/generateOgImages.ts
@@ -1,7 +1,7 @@
 import type { CollectionEntry } from 'astro:content'
 import { Resvg } from '@resvg/resvg-js'
-import postOgImage from './og-templates/post'
-import siteOgImage from './og-templates/site'
+import postOgImage from './og-templates/post.js'
+import siteOgImage from './og-templates/site.js'
 
 function svgBufferToPngBuffer(svg: string) {
   const resvg = new Resvg(svg)

--- a/apps/blog/src/utils/loadGoogleFont.ts
+++ b/apps/blog/src/utils/loadGoogleFont.ts
@@ -36,6 +36,18 @@ async function loadGoogleFonts(
 > {
   const fontsConfig = [
     {
+      name: 'Noto Sans JP',
+      font: 'Noto+Sans+JP',
+      weight: 400,
+      style: 'normal',
+    },
+    {
+      name: 'Noto Sans JP',
+      font: 'Noto+Sans+JP',
+      weight: 700,
+      style: 'bold',
+    },
+    {
       name: 'IBM Plex Mono',
       font: 'IBM+Plex+Mono',
       weight: 400,

--- a/apps/blog/src/utils/og-templates/post.js
+++ b/apps/blog/src/utils/og-templates/post.js
@@ -1,98 +1,6 @@
-// import { html } from "satori-html";
-
 import satori from 'satori'
 import { SITE } from '@/config'
 import loadGoogleFonts from '../loadGoogleFont'
-
-// const markup = html`<div
-//       style={{
-//         background: "#fefbfb",
-//         width: "100%",
-//         height: "100%",
-//         display: "flex",
-//         alignItems: "center",
-//         justifyContent: "center",
-//       }}
-//     >
-//       <div
-//         style={{
-//           position: "absolute",
-//           top: "-1px",
-//           right: "-1px",
-//           border: "4px solid #000",
-//           background: "#ecebeb",
-//           opacity: "0.9",
-//           borderRadius: "4px",
-//           display: "flex",
-//           justifyContent: "center",
-//           margin: "2.5rem",
-//           width: "88%",
-//           height: "80%",
-//         }}
-//       />
-
-//       <div
-//         style={{
-//           border: "4px solid #000",
-//           background: "#fefbfb",
-//           borderRadius: "4px",
-//           display: "flex",
-//           justifyContent: "center",
-//           margin: "2rem",
-//           width: "88%",
-//           height: "80%",
-//         }}
-//       >
-//         <div
-//           style={{
-//             display: "flex",
-//             flexDirection: "column",
-//             justifyContent: "space-between",
-//             margin: "20px",
-//             width: "90%",
-//             height: "90%",
-//           }}
-//         >
-//           <p
-//             style={{
-//               fontSize: 72,
-//               fontWeight: "bold",
-//               maxHeight: "84%",
-//               overflow: "hidden",
-//             }}
-//           >
-//             {post.data.title}
-//           </p>
-//           <div
-//             style={{
-//               display: "flex",
-//               justifyContent: "space-between",
-//               width: "100%",
-//               marginBottom: "8px",
-//               fontSize: 28,
-//             }}
-//           >
-//             <span>
-//               by{" "}
-//               <span
-//                 style={{
-//                   color: "transparent",
-//                 }}
-//               >
-//                 "
-//               </span>
-//               <span style={{ overflow: "hidden", fontWeight: "bold" }}>
-//                 {post.data.author}
-//               </span>
-//             </span>
-
-//             <span style={{ overflow: "hidden", fontWeight: "bold" }}>
-//               {SITE.title}
-//             </span>
-//           </div>
-//         </div>
-//       </div>
-//     </div>`;
 
 export default async (post) => {
   return satori(
@@ -100,30 +8,28 @@ export default async (post) => {
       type: 'div',
       props: {
         style: {
-          background: '#fefbfb',
+          background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
           width: '100%',
           height: '100%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
+          fontFamily: 'Noto Sans JP, IBM Plex Mono',
+          position: 'relative',
         },
         children: [
+          // 装飾用の図形
           {
             type: 'div',
             props: {
               style: {
                 position: 'absolute',
-                top: '-1px',
-                right: '-1px',
-                border: '4px solid #000',
-                background: '#ecebeb',
-                opacity: '0.9',
-                borderRadius: '4px',
-                display: 'flex',
-                justifyContent: 'center',
-                margin: '2.5rem',
-                width: '88%',
-                height: '80%',
+                top: '0',
+                right: '0',
+                width: '300px',
+                height: '300px',
+                background: 'rgba(255, 255, 255, 0.1)',
+                borderRadius: '0 0 0 300px',
               },
             },
           },
@@ -131,90 +37,155 @@ export default async (post) => {
             type: 'div',
             props: {
               style: {
-                border: '4px solid #000',
-                background: '#fefbfb',
-                borderRadius: '4px',
-                display: 'flex',
-                justifyContent: 'center',
-                margin: '2rem',
-                width: '88%',
-                height: '80%',
+                position: 'absolute',
+                bottom: '0',
+                left: '0',
+                width: '200px',
+                height: '200px',
+                background: 'rgba(255, 255, 255, 0.05)',
+                borderRadius: '0 200px 0 0',
               },
-              children: {
-                type: 'div',
-                props: {
-                  style: {
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'space-between',
-                    margin: '20px',
-                    width: '90%',
-                    height: '90%',
+            },
+          },
+          // メインカード
+          {
+            type: 'div',
+            props: {
+              style: {
+                background: 'rgba(255, 255, 255, 0.98)',
+                borderRadius: '32px',
+                boxShadow: '0 32px 80px rgba(0, 0, 0, 0.25)',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'space-between',
+                padding: '40px',
+                margin: '60px',
+                width: '1080px',
+                height: '480px',
+                border: '1px solid rgba(255, 255, 255, 0.3)',
+              },
+              children: [
+                // トップセクション - バッジ
+                {
+                  type: 'div',
+                  props: {
+                    style: {
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      marginBottom: '30px',
+                    },
+                    children: [
+                      {
+                        type: 'div',
+                        props: {
+                          style: {
+                            background:
+                              'linear-gradient(135deg, #ff6b6b, #feca57)',
+                            padding: '14px 28px',
+                            borderRadius: '50px',
+                            color: 'white',
+                            fontSize: '24px',
+                            fontWeight: '700',
+                            letterSpacing: '1px',
+                            fontFamily: 'Noto Sans JP',
+                            textShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
+                          },
+                          children: '投稿',
+                        },
+                      },
+                    ],
                   },
-                  children: [
-                    {
-                      type: 'p',
+                },
+                // タイトルセクション
+                {
+                  type: 'div',
+                  props: {
+                    style: {
+                      flex: '1',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      textAlign: 'center',
+                      padding: '20px 40px',
+                      overflow: 'hidden',
+                    },
+                    children: {
+                      type: 'h1',
                       props: {
                         style: {
-                          fontSize: 72,
-                          fontWeight: 'bold',
-                          maxHeight: '84%',
+                          fontSize:
+                            post.data.title.length > 50
+                              ? '32px'
+                              : post.data.title.length > 30
+                                ? '38px'
+                                : '44px',
+                          fontWeight: '900',
+                          lineHeight: '1.3',
+                          margin: '0',
+                          background:
+                            'linear-gradient(135deg, #667eea, #764ba2)',
+                          WebkitBackgroundClip: 'text',
+                          WebkitTextFillColor: 'transparent',
+                          backgroundClip: 'text',
+                          maxWidth: '950px',
                           overflow: 'hidden',
-                          fontFamily: 'Noto Sans JP, IBM Plex Mono',
+                          display: 'block',
+                          textOverflow: 'ellipsis',
+                          wordBreak: 'break-word',
+                          maxHeight: '280px',
+                          fontFamily: 'Noto Sans JP',
                         },
                         children: post.data.title,
                       },
                     },
-                    {
-                      type: 'div',
-                      props: {
-                        style: {
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          width: '100%',
-                          marginBottom: '8px',
-                          fontSize: 28,
-                          fontFamily: 'Noto Sans JP, IBM Plex Mono',
-                        },
-                        children: [
-                          {
-                            type: 'span',
-                            props: {
-                              children: [
-                                'by ',
-                                {
-                                  type: 'span',
-                                  props: {
-                                    style: { color: 'transparent' },
-                                    children: '"',
-                                  },
-                                },
-                                {
-                                  type: 'span',
-                                  props: {
-                                    style: {
-                                      overflow: 'hidden',
-                                      fontWeight: 'bold',
-                                    },
-                                    children: post.data.author,
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                          {
-                            type: 'span',
-                            props: {
-                              style: { overflow: 'hidden', fontWeight: 'bold' },
-                              children: SITE.title,
-                            },
-                          },
-                        ],
-                      },
-                    },
-                  ],
+                  },
                 },
-              },
+                // ボトムセクション
+                {
+                  type: 'div',
+                  props: {
+                    style: {
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      paddingTop: '30px',
+                      borderTop: '2px solid #f0f0f0',
+                      marginTop: '20px',
+                    },
+                    children: [
+                      {
+                        type: 'div',
+                        props: {
+                          style: {
+                            color: '#666666',
+                            fontSize: '28px',
+                            fontWeight: '600',
+                            fontFamily: 'Noto Sans JP',
+                          },
+                          children: post.data.author || 'Author',
+                        },
+                      },
+                      {
+                        type: 'div',
+                        props: {
+                          style: {
+                            background:
+                              'linear-gradient(135deg, #667eea, #764ba2)',
+                            WebkitBackgroundClip: 'text',
+                            WebkitTextFillColor: 'transparent',
+                            backgroundClip: 'text',
+                            fontSize: '36px',
+                            fontWeight: '800',
+                            fontFamily: 'Noto Sans JP',
+                          },
+                          children: SITE.title,
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
             },
           },
         ],
@@ -225,7 +196,7 @@ export default async (post) => {
       height: 630,
       embedFont: true,
       fonts: await loadGoogleFonts(
-        `${post.data.title}${post.data.author}${SITE.title}by`,
+        `${post.data.title}${post.data.author || 'Author'}${SITE.title}投稿`,
       ),
     },
   )

--- a/apps/blog/src/utils/og-templates/post.js
+++ b/apps/blog/src/utils/og-templates/post.js
@@ -160,6 +160,7 @@ export default async (post) => {
                           fontWeight: 'bold',
                           maxHeight: '84%',
                           overflow: 'hidden',
+                          fontFamily: 'Noto Sans JP, IBM Plex Mono',
                         },
                         children: post.data.title,
                       },
@@ -173,6 +174,7 @@ export default async (post) => {
                           width: '100%',
                           marginBottom: '8px',
                           fontSize: 28,
+                          fontFamily: 'Noto Sans JP, IBM Plex Mono',
                         },
                         children: [
                           {

--- a/apps/blog/src/utils/og-templates/site.js
+++ b/apps/blog/src/utils/og-templates/site.js
@@ -77,14 +77,21 @@ export default async () => {
                           {
                             type: 'p',
                             props: {
-                              style: { fontSize: 72, fontWeight: 'bold' },
+                              style: { 
+                                fontSize: 72, 
+                                fontWeight: 'bold',
+                                fontFamily: 'Noto Sans JP, IBM Plex Mono',
+                              },
                               children: SITE.title,
                             },
                           },
                           {
                             type: 'p',
                             props: {
-                              style: { fontSize: 28 },
+                              style: { 
+                                fontSize: 28,
+                                fontFamily: 'Noto Sans JP, IBM Plex Mono',
+                              },
                               children: SITE.desc,
                             },
                           },
@@ -100,6 +107,7 @@ export default async () => {
                           width: '100%',
                           marginBottom: '8px',
                           fontSize: 28,
+                          fontFamily: 'Noto Sans JP, IBM Plex Mono',
                         },
                         children: {
                           type: 'span',

--- a/apps/blog/src/utils/og-templates/site.js
+++ b/apps/blog/src/utils/og-templates/site.js
@@ -8,30 +8,28 @@ export default async () => {
       type: 'div',
       props: {
         style: {
-          background: '#fefbfb',
+          background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
           width: '100%',
           height: '100%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
+          fontFamily: 'Noto Sans JP, IBM Plex Mono',
+          position: 'relative',
         },
         children: [
+          // 装飾用の円形背景
           {
             type: 'div',
             props: {
               style: {
                 position: 'absolute',
-                top: '-1px',
-                right: '-1px',
-                border: '4px solid #000',
-                background: '#ecebeb',
-                opacity: '0.9',
-                borderRadius: '4px',
-                display: 'flex',
-                justifyContent: 'center',
-                margin: '2.5rem',
-                width: '88%',
-                height: '80%',
+                top: '-150px',
+                right: '-150px',
+                width: '400px',
+                height: '400px',
+                borderRadius: '50%',
+                background: 'rgba(255, 255, 255, 0.1)',
               },
             },
           },
@@ -39,88 +37,97 @@ export default async () => {
             type: 'div',
             props: {
               style: {
-                border: '4px solid #000',
-                background: '#fefbfb',
-                borderRadius: '4px',
+                position: 'absolute',
+                bottom: '-200px',
+                left: '-200px',
+                width: '500px',
+                height: '500px',
+                borderRadius: '50%',
+                background: 'rgba(255, 255, 255, 0.05)',
+              },
+            },
+          },
+          // メインカード
+          {
+            type: 'div',
+            props: {
+              style: {
+                background: 'rgba(255, 255, 255, 0.95)',
+                borderRadius: '32px',
+                boxShadow: '0 25px 80px rgba(0, 0, 0, 0.3)',
                 display: 'flex',
+                flexDirection: 'column',
                 justifyContent: 'center',
-                margin: '2rem',
-                width: '88%',
+                alignItems: 'center',
+                padding: '80px',
+                margin: '60px',
+                width: '85%',
                 height: '80%',
+                border: '3px solid rgba(255, 255, 255, 0.3)',
+                textAlign: 'center',
               },
-              children: {
-                type: 'div',
-                props: {
-                  style: {
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'space-between',
-                    margin: '20px',
-                    width: '90%',
-                    height: '90%',
+              children: [
+                // タイトル部分
+                {
+                  type: 'h1',
+                  props: {
+                    style: {
+                      fontSize: '84px',
+                      fontWeight: '900',
+                      margin: '0 0 30px 0',
+                      background: 'linear-gradient(45deg, #667eea, #764ba2)',
+                      WebkitBackgroundClip: 'text',
+                      WebkitTextFillColor: 'transparent',
+                      backgroundClip: 'text',
+                      letterSpacing: '-2px',
+                      fontFamily: 'Noto Sans JP',
+                    },
+                    children: SITE.title,
                   },
-                  children: [
-                    {
-                      type: 'div',
-                      props: {
-                        style: {
-                          display: 'flex',
-                          flexDirection: 'column',
-                          justifyContent: 'center',
-                          alignItems: 'center',
-                          height: '90%',
-                          maxHeight: '90%',
-                          overflow: 'hidden',
-                          textAlign: 'center',
-                        },
-                        children: [
-                          {
-                            type: 'p',
-                            props: {
-                              style: { 
-                                fontSize: 72, 
-                                fontWeight: 'bold',
-                                fontFamily: 'Noto Sans JP, IBM Plex Mono',
-                              },
-                              children: SITE.title,
-                            },
-                          },
-                          {
-                            type: 'p',
-                            props: {
-                              style: { 
-                                fontSize: 28,
-                                fontFamily: 'Noto Sans JP, IBM Plex Mono',
-                              },
-                              children: SITE.desc,
-                            },
-                          },
-                        ],
-                      },
-                    },
-                    {
-                      type: 'div',
-                      props: {
-                        style: {
-                          display: 'flex',
-                          justifyContent: 'flex-end',
-                          width: '100%',
-                          marginBottom: '8px',
-                          fontSize: 28,
-                          fontFamily: 'Noto Sans JP, IBM Plex Mono',
-                        },
-                        children: {
-                          type: 'span',
-                          props: {
-                            style: { overflow: 'hidden', fontWeight: 'bold' },
-                            children: new URL(SITE.website).hostname,
-                          },
-                        },
-                      },
-                    },
-                  ],
                 },
-              },
+                // 説明文部分
+                {
+                  type: 'p',
+                  props: {
+                    style: {
+                      fontSize: '36px',
+                      color: '#666666',
+                      margin: '0 0 50px 0',
+                      fontWeight: '500',
+                      lineHeight: '1.4',
+                      fontFamily: 'Noto Sans JP',
+                    },
+                    children: SITE.desc,
+                  },
+                },
+                // ウェブサイト部分
+                {
+                  type: 'div',
+                  props: {
+                    style: {
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      padding: '20px 40px',
+                      background: 'linear-gradient(135deg, #ff6b6b, #feca57)',
+                      borderRadius: '25px',
+                      color: 'white',
+                      fontSize: '32px',
+                      fontWeight: '600',
+                      fontFamily: 'Noto Sans JP',
+                      textShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
+                    },
+                    children: [
+                      {
+                        type: 'span',
+                        props: {
+                          children: new URL(SITE.website).hostname,
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
             },
           },
         ],
@@ -130,7 +137,7 @@ export default async () => {
       width: 1200,
       height: 630,
       embedFont: true,
-      fonts: await loadGoogleFonts(SITE.title + SITE.desc + SITE.website),
+      fonts: await loadGoogleFonts(`${SITE.title}${SITE.desc}${SITE.website}`),
     },
   )
 }


### PR DESCRIPTION
Add Noto Sans JP font with normal and bold weights to the Google Fonts
loader configuration. Update site and post OG image templates to use a
font stack including Noto Sans JP and IBM Plex Mono for titles and
descriptions. This improves typography consistency and supports Japanese
characters in generated OG images.