### PR TITLE
fix(deps): pin remark-toc version to 9.0.0

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -17,7 +17,7 @@
     "dayjs": "1.11.13",
     "lodash.kebabcase": "4.1.1",
     "remark-collapse": "0.1.2",
-    "remark-toc": "^9.0.0",
+    "remark-toc": "9.0.0",
     "satori": "0.15.2",
     "sharp": "0.34.2",
     "tailwindcss": "4.1.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: 0.1.2
         version: 0.1.2
       remark-toc:
-        specifier: ^9.0.0
+        specifier: 9.0.0
         version: 9.0.0
       satori:
         specifier: 0.15.2


### PR DESCRIPTION
Update remark-toc dependency specifier from ^9.0.0 to 9.0.0 in both
pnpm-lock.yaml and apps/blog/package.json to ensure consistent and
deterministic installs. This change prevents unintended upgrades that
could introduce breaking changes.