### PR TITLE
docs: add language and filename info to code blocks

### DIFF
--- a/apps/blog/src/data/blog/arch-linux-setup.md
+++ b/apps/blog/src/data/blog/arch-linux-setup.md
@@ -66,7 +66,7 @@ sudo vi /etc/ssh/sshd_config
 
 `/etc/ssh/sshd_config`のファイル修正して以下のあたりの設定追加。
 
-```bash:/etc/ssh/sshd_config
+```bash file="/etc/ssh/sshd_config"
 PubkeyAuthentication yes
 PasswordAuthentication no
 ```

--- a/apps/blog/src/data/blog/prisma.md
+++ b/apps/blog/src/data/blog/prisma.md
@@ -22,7 +22,7 @@ prismaは.envの内容を読んでschemaを登録するDBを決めれる。
 開発時は開発用のDBに繋げて、本番環境に上げる時に、ciの環境変数で本番用のDBをセットするのが良さそう。
 ワイはvercelのbuild後にdb migrate deployをやるようにしたら今のところはいい感じ。
 
-```turbo.json
+```json file="turbo.json"
     "build": {
       "dependsOn": ["^build", "^db:generate"],
       "outputs": [
@@ -52,7 +52,7 @@ migrationを作成しないだけでdbのschemaを適用させる。開発途中
 
 prisma clientのnode_modulesに設定したschemaのメソッドみたいなのが作られる。それをimportすることで制御できるみたい。
 
-```schema.prisma
+```prisma file="schema.prisma"
 model Todo {
   id      String @id @default(cuid())
   content String

--- a/apps/blog/src/data/blog/shadcn.md
+++ b/apps/blog/src/data/blog/shadcn.md
@@ -45,7 +45,7 @@ tsconfig.json, package.json, components.jsonを最終こんな感じで記載し
 
 packages/ui/components.json
 
-```packages/ui/components.json
+```json file="packages/ui/components.json"
 {
   "$schema": "<https://ui.shadcn.com/schema.json>",
   "style": "default",
@@ -67,7 +67,7 @@ packages/ui/components.json
 
 packages/ui/package.json
 
-```packages/ui/package.json
+```json file="packages/ui/package.json"
   ...
   "exports": {
     "./*": "./src/components/*.tsx",
@@ -85,7 +85,7 @@ packages/ui/package.json
 
 packages/ui/tsconfig.json
 
-```packages/ui/tsconfig.json
+```json file="packages/ui/tsconfig.json"
 {
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
@@ -106,7 +106,7 @@ packages/ui/tsconfig.json
 
 なのでpackage.jsonでimportsにsubpathの指定を書く。`src/lib/*.ts`にマッチするものを全て`#deps/lib/*`でimportするって書いてたら使う側で適当に解決してくれるっぽい。
 
-```packages/ui/components/ui/accordion.tsx
+```typescript file="packages/ui/components/ui/accordion.tsx"
 'use client';
 
 import * as AccordionPrimitive from '@radix-ui/react-accordion';


### PR DESCRIPTION
Add explicit language and filename annotations to fenced code blocks in
multiple markdown files to improve syntax highlighting and clarity in
documentation. This change enhances readability and developer experience
when viewing code snippets in the blog and UI package docs.