### PR TITLE
chore(release): enable draft releases for release-please

### DIFF
--- a/.github/files/release-please/release-please-config.json
+++ b/.github/files/release-please/release-please-config.json
@@ -68,7 +68,7 @@
       "release-type": "node",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "draft": false,
+      "draft": true,
       "prerelease": false,
       "include-component-in-tag": false,
       "pull-request-title-pattern": "release: v${version}"


### PR DESCRIPTION
Set the release-please config to create draft releases instead of
publishing them immediately. This change sets "draft" to true so
release PRs remain in draft state, allowing manual review or
additional adjustments before finalizing the release. It helps
prevent accidental publishes and gives maintainers time to verify
release artifacts and notes.