### PR TITLE
fix: publish releases instead of drafting

### DIFF
--- a/.github/files/release-please/release-please-config.json
+++ b/.github/files/release-please/release-please-config.json
@@ -68,7 +68,7 @@
       "release-type": "node",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "draft": true,
+      "draft": false,
       "prerelease": false,
       "include-component-in-tag": false,
       "pull-request-title-pattern": "release: v${version}"


### PR DESCRIPTION
Set release-please to mark releases as published (draft=false) so
release PRs create-draft releases. This ensures releases are
visible immediately after publishing and streamlines release
automation by removing the extra manual step of promoting drafts.