### PR TITLE
fix(blog): normalize pubDatetime to date-only formatUpdate frontmatte…

### DIFF
--- a/apps/blog/CLAUDE.md
+++ b/apps/blog/CLAUDE.md
@@ -34,7 +34,7 @@
 
 ```yaml
 ---
-pubDatetime: 2026-01-30T15:10:00+09:00  # ISO 8601 + タイムゾーン
+pubDatetime: 2026-01-30  # YYYY-MM-DD（時間は不要）
 title: '記事タイトル'
 featured: true  # トップに出すかどうか
 slug: kebab-case-slug  # URL用。ファイル名のslug部分と一致させる

--- a/apps/blog/src/components/Datetime.astro
+++ b/apps/blog/src/components/Datetime.astro
@@ -30,7 +30,6 @@ const latestDatetime =
 const datetime = dayjs(latestDatetime).tz(postTimezone || SITE.timezone)
 
 const date = datetime.format('D MMM, YYYY') // e.g., '22 Mar, 2025'
-const time = datetime.format('hh:mm A') // e.g., '08:30 PM'
 ---
 
 <div class:list={["flex items-end space-x-2 opacity-80", className]}>
@@ -51,8 +50,5 @@ const time = datetime.format('hh:mm A') // e.g., '08:30 PM'
   }
   <span class:list={["text-sm italic", { "sm:text-base": size === "lg" }]}>
     <time datetime={datetime.toISOString()}>{date}</time>
-    <span aria-hidden="true"> | </span>
-    <span class="sr-only">&nbsp;at&nbsp;</span>
-    <span class="text-nowrap">{time}</span>
   </span>
 </div>

--- a/apps/blog/src/data/blog/01_new-post.md
+++ b/apps/blog/src/data/blog/01_new-post.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2024-04-10T05:40:47.644Z
+pubDatetime: 2024-04-10
 title: ブログを移行してみたよ
 featured: false
 draft: true

--- a/apps/blog/src/data/blog/02_js-array-kirai.md
+++ b/apps/blog/src/data/blog/02_js-array-kirai.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2024-04-11T11:52:01.651Z
+pubDatetime: 2024-04-11
 title: JavaScript難しい
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/03_shiki-highlight.md
+++ b/apps/blog/src/data/blog/03_shiki-highlight.md
@@ -1,6 +1,6 @@
 ---
 title: Shiki Highlight
-pubDatetime: 2024-04-11T11:52:01.651Z
+pubDatetime: 2024-04-11
 featured: false
 draft: true
 slug: shiki-highlight

--- a/apps/blog/src/data/blog/04_arch-linux-setup.md
+++ b/apps/blog/src/data/blog/04_arch-linux-setup.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2024-05-20T18:59:01.651Z
+pubDatetime: 2024-05-20
 title: ノートPCにSSHできるようにしてみた
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/05_prisma.md
+++ b/apps/blog/src/data/blog/05_prisma.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2024-06-19T05:40:47.644Z
+pubDatetime: 2024-06-19
 title: prismaを使ってみた
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/06_shadcn.md
+++ b/apps/blog/src/data/blog/06_shadcn.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2024-06-19T05:40:47.644Z
+pubDatetime: 2024-06-19
 title: shadcnをmonorepoに入れてみた
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/07_update-playground.md
+++ b/apps/blog/src/data/blog/07_update-playground.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2024-06-26T06:59:08.071Z
+pubDatetime: 2024-06-26
 title: PlaygroundにTodoアプリを実装
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/08_new-dotfiles.md
+++ b/apps/blog/src/data/blog/08_new-dotfiles.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2024-07-16T07:33:08.279Z
+pubDatetime: 2024-07-16
 title: とうとう、私だけのdotfilesできた！
 featured: false
 draft: true

--- a/apps/blog/src/data/blog/09_chrome-devtool-response-override.md
+++ b/apps/blog/src/data/blog/09_chrome-devtool-response-override.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2024-07-16T08:57:51.484Z
+pubDatetime: 2024-07-16
 title: DevtoolのResponse Header Overrideが便利だった
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/10_create-wordpress-site.md
+++ b/apps/blog/src/data/blog/10_create-wordpress-site.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2024-08-12T13:13:39.874Z
+pubDatetime: 2024-08-12
 title: Wordpressを構築！改めて色々わかった気がする
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/11_repository-clean.md
+++ b/apps/blog/src/data/blog/11_repository-clean.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-02-06T03:24:24.109Z
+pubDatetime: 2025-02-06
 title: リポジトリを綺麗にした
 featured: false
 draft: true

--- a/apps/blog/src/data/blog/12_turbo-devcontainer.md
+++ b/apps/blog/src/data/blog/12_turbo-devcontainer.md
@@ -1,6 +1,6 @@
 ---
 title: Devcontainerで環境変数が呼び出せず詰んだ話と解決策
-pubDatetime: 2025-02-13T12:54:43.125Z
+pubDatetime: 2025-02-13
 featured: false
 draft: false
 slug: turbo-devcontainer

--- a/apps/blog/src/data/blog/13_try-test.md
+++ b/apps/blog/src/data/blog/13_try-test.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-06-25T03:58:05.898Z
+pubDatetime: 2025-06-25
 title: テストに慣れてない自分が考えた、フロントエンドでのテストとの付き合い方
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/14_react-test-provider-wrapper.md
+++ b/apps/blog/src/data/blog/14_react-test-provider-wrapper.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-06-26T13:57:51.484Z
+pubDatetime: 2025-06-26
 title: 'React Testing: ProviderWrapperを作ってテスト環境を楽にしてみた'
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/15_mcp-playwright-experience.md
+++ b/apps/blog/src/data/blog/15_mcp-playwright-experience.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-07-01T02:30:00+09:00
+pubDatetime: 2025-07-01
 title: 'MCP + Playwrightを使ってみた: 実際の作業をAIエージェントにやらせてみた感想'
 featured: false
 draft: false

--- a/apps/blog/src/data/blog/16_legacy_e2e_strategy.md
+++ b/apps/blog/src/data/blog/16_legacy_e2e_strategy.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-07-09T13:00:00+09:00
+pubDatetime: 2025-07-09
 title: レガシーコードにE2Eを追加していく戦略と考え方
 slug: legacy-e2e-strategy
 featured: false

--- a/apps/blog/src/data/blog/17_gitbutler-vscode-remote-ssh.md
+++ b/apps/blog/src/data/blog/17_gitbutler-vscode-remote-ssh.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-07-09T22:16:00.000Z
+pubDatetime: 2025-07-09
 title: GitButlerとVSCode Remote SSH - リモート開発での課題と解決策
 slug: gitbutler-vscode-remote-ssh
 featured: false

--- a/apps/blog/src/data/blog/18_line-bot-mugi.md
+++ b/apps/blog/src/data/blog/18_line-bot-mugi.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-07-21T22:27:00+09:00
+pubDatetime: 2025-07-21
 title: 'LINE Bot × AI：1週間でAIチャットボットを作ってみた振り返り'
 featured: false
 slug: line-bot-mugi

--- a/apps/blog/src/data/blog/19_hazukasi.md
+++ b/apps/blog/src/data/blog/19_hazukasi.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-07-29T07:52:00+09:00
+pubDatetime: 2025-07-29
 title: '公開しているものが恥ずかしくなる'
 featured: false
 slug: embarrassing-publications

--- a/apps/blog/src/data/blog/20_infrastructure-learning-journey.md
+++ b/apps/blog/src/data/blog/20_infrastructure-learning-journey.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-10-17T20:08:00+09:00
+pubDatetime: 2025-10-17
 title: 'インフラを学びたい気持ちと「支えることで、世界を形づくる」'
 featured: false
 slug: infrastructure-learning-journey

--- a/apps/blog/src/data/blog/21_quo-card-gap.md
+++ b/apps/blog/src/data/blog/21_quo-card-gap.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-11-09T18:15:00+09:00
+pubDatetime: 2025-11-09
 title: 'QUOカードもらったけど使い道に困る問題'
 featured: false
 slug: quo-card-gap

--- a/apps/blog/src/data/blog/22_k3s-wordpress-on-oracle-cloud.md
+++ b/apps/blog/src/data/blog/22_k3s-wordpress-on-oracle-cloud.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-11-12T10:45:00+09:00
+pubDatetime: 2025-11-12
 title: 'Oracle CloudでK3s環境構築してWordPressをデプロイした話'
 featured: false
 slug: k3s-wordpress-on-oracle-cloud

--- a/apps/blog/src/data/blog/23_k3s-data-loss-incident.md
+++ b/apps/blog/src/data/blog/23_k3s-data-loss-incident.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-11-15T17:00:00+09:00
+pubDatetime: 2025-11-15
 title: '【悲報】K3sのデータが全部消えた話 - Terraformとboot volumeの落とし穴'
 featured: false
 slug: k3s-data-loss-incident

--- a/apps/blog/src/data/blog/24_recent-dev-summary.md
+++ b/apps/blog/src/data/blog/24_recent-dev-summary.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2025-01-01T09:59:00+09:00
+pubDatetime: 2025-01-01
 title: '最近の開発ざっくりまとめ'
 featured: true
 slug: recent-dev-summary

--- a/apps/blog/src/data/blog/25_cant-be-interested-in-people.md
+++ b/apps/blog/src/data/blog/25_cant-be-interested-in-people.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2026-01-06T09:52:00+09:00
+pubDatetime: 2026-01-06
 title: '29歳、人に興味が持てなくて辛いという話'
 featured: false
 slug: 29-cant-be-interested-in-people

--- a/apps/blog/src/data/blog/26_mikke-release.md
+++ b/apps/blog/src/data/blog/26_mikke-release.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2026-01-27T14:27:00+09:00
+pubDatetime: 2026-01-27
 title: 'Mikkeリリースしました🎉'
 featured: true
 slug: mikke-release

--- a/apps/blog/src/data/blog/28_ai-video-music-generation.md
+++ b/apps/blog/src/data/blog/28_ai-video-music-generation.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2026-01-30T15:10:00+09:00
+pubDatetime: 2026-01-30
 title: 'AIの動画・音楽生成を試してみた'
 featured: true
 slug: ai-video-music-generation

--- a/apps/blog/src/data/blog/29_readme-gen.md
+++ b/apps/blog/src/data/blog/29_readme-gen.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2026-01-30T19:54:00+09:00
+pubDatetime: 2026-01-30
 title: 'readme-genを作ってみた'
 featured: true
 slug: readme-gen

--- a/apps/blog/src/data/blog/30_indie-dev-infra-and-future.md
+++ b/apps/blog/src/data/blog/30_indie-dev-infra-and-future.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2026-01-30T20:00:00+09:00
+pubDatetime: 2026-01-30
 title: '個人開発のインフラ奮闘記とこれからの働き方'
 featured: false
 slug: indie-dev-infra-and-future

--- a/apps/blog/src/data/blog/31_testing-dx-and-feedback.md
+++ b/apps/blog/src/data/blog/31_testing-dx-and-feedback.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2026-02-05T13:00:00+09:00
+pubDatetime: 2026-02-05
 title: 'パフォーマンスより先にやること'
 featured: false
 slug: testing-dx-and-feedback


### PR DESCRIPTION
…r pubDatetime in multiple blog markdown to useYYYY-MM-DD (date-only) instead of full ISO timestamps with time andtimezone. update CLAUDE.md example to reflect the date-only format.

This standardizes publication metadata, simplifies parsing and avoidstimezone-related inconsistencies when rendering or sorting posts.